### PR TITLE
Convert config boolean to int for sendAppMessage

### DIFF
--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -18,7 +18,7 @@ Pebble.addEventListener('webviewclosed', function(e) {
   if (configData.backgroundColor) {
     Pebble.sendAppMessage({
       backgroundColor: parseInt(configData.backgroundColor, 16),
-      twentyFourHourFormat: configData.twentyFourHourFormat
+      twentyFourHourFormat: configData.twentyFourHourFormat ? 1 : 0
     }, function() {
       console.log('Send successful!');
     }, function() {


### PR DESCRIPTION
Although original version works with emulator, Pebble app won't send config checkbox data properly unless boolean data is converted to integers.
